### PR TITLE
Fix go get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bitbucket.org/exyzzy/hershey
+module github.com/exyzzy/hershey
 
 go 1.16
 


### PR DESCRIPTION
Thanks for the module, it looks great!

Currently go get fails due to the path in the go.mod file:

```
go: downloading github.com/exyzzy/hershey v0.0.0-20210918043116-4417c90c656f
go: github.com/exyzzy/hershey@v0.0.0-20210918043116-4417c90c656f: parsing go.mod:
	module declares its path as: bitbucket.org/exyzzy/hershey
	        but was required as: github.com/exyzzy/hershey
```

This patch should fix that issue.